### PR TITLE
add ant buildfile for easy automatic builds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,45 @@
+<project name="Factory" default="dist" basedir=".">
+  <description>
+    simple example build file
+  </description>
+  <!-- set global properties for this build -->
+  <property name="src" location="src"/>
+  <property name="build" location="build"/>
+  <property name="dist" location="dist"/>
+  <property name="resources" location="res"/>
+
+  <target name="init">
+    <!-- Create the time stamp -->
+    <tstamp/>
+    <!-- Create the build directory structure used by compile -->
+    <mkdir dir="${build}"/>
+  </target>
+
+  <target name="compile" depends="init"
+        description="compile the source">
+    <!-- Compile the Java code from ${src} into ${build} -->
+    <javac srcdir="${src}" destdir="${build}"/>
+  </target>
+
+  <target name="dist" depends="compile"
+        description="generate the distribution">
+    <!-- Create the distribution directory -->
+    <mkdir dir="${dist}/lib"/>
+
+    <!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
+    <jar jarfile="${dist}/lib/Factory.jar">
+	    <fileset dir='${build}'/>
+	    <fileset dir='${resources}'/>
+	    <manifest>
+		    <attribute name="Main-Class" value="com.sinius15.factory.FactoryGame"/>
+	    </manifest>
+    </jar>
+  </target>
+
+  <target name="clean"
+        description="clean up">
+    <!-- Delete the ${build} and ${dist} directory trees -->
+    <delete dir="${build}"/>
+    <delete dir="${dist}"/>
+  </target>
+</project>


### PR DESCRIPTION
One can then build everything with ant and quickly launch from terminal.  
In freshly cloned directory:

```
ant
java -jar dist/lib/Factory.jar  
```

Automatic building like this is useful when you do packaging for Linux and in general for people to be able to quickly build and play from sources.